### PR TITLE
Added a relative to the root of the project option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ Calling `autoload(__dirname)` will give:
 Where `exportsFromFile` is the value returned by the file `module.exports`.
 
 > Non js or json files are not loaded.
+
+You can load the files with two types of paths:
+
+- Absolute, in which case the files will be included from the full path:
+
+```js
+autoload(__dirname);
+autoload(__dirname + '/directory')
+```
+
+- Relative, in which case the files will be loaded relative to the root of your project (where the node instance is being executed). To do this, you simply have to pass the name of the file:
+
+```js
+// will load /username/projectname/directory
+autoload('directory');
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,5 +47,8 @@ var walk = function(path) {
 
 // Main function.
 module.exports = function autoload(baseDirectory) {
+  if (!baseDirectory.match(/^\//)) {
+    baseDirectory = process.cwd() + '/' + baseDirectory;
+  }
   return walk(baseDirectory);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,11 @@ var walk = function(path) {
 
 // Main function.
 module.exports = function autoload(baseDirectory) {
-  if (!baseDirectory.match(/^\//)) {
+
+  // Check if it's absolute
+  // http://stackoverflow.com/q/21698906/938236
+  var normalized = systemPath.normalize(baseDirectory).replace(/[\/|\\]$/, '');
+  if (systemPath.resolve(baseDirectory) !== normalized) {
     baseDirectory = process.cwd() + '/' + baseDirectory;
   }
   return walk(baseDirectory);

--- a/test/index.js
+++ b/test/index.js
@@ -23,4 +23,22 @@ describe("Autoload", function() {
       }
     });
   });
+
+  it("should load all subdirectories based on root", function(){
+    var tree = autoload("test/test-tree");
+
+    tree.should.eql({
+      '1': 1,
+      '2': 2,
+      'withDash': "with-dash",
+      '3': {
+        '31': 31,
+        '32': {
+          '321': {
+            value: 3
+          }
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
After weighting in everything [shared in here](https://github.com/Neamar/auto-load/issues/3#issuecomment-143195962), the relative-to-the-file solutions is not possible without the Error hack. So I propose the other alternative I outlined initially: make it able to load files relative to the root of the project.

It's actually more convenient; you can have the same notation in all folders. If you wanted to include, say all models in different files, you have to track each time in which level you are and you are not able to move the file through levels without changing them. In this way, you just need to do:

```js
var models = require('auto-load')('models');
```

For this structure:

```
/models
/controllers
/test
  /models
```

Independently of the level you are. So in `/test/models/index.js` you have to write the same as in `/controllers/index.js`, which is convenient. This is the same as *external* npm modules included with `require()`, but however different to your own required files.

It is also backward compatible, so your old autoloads still work the same:

```js
var models = require('auto-load')(__dirname + '/../models');
```

For this I used [this script](http://stackoverflow.com/q/21698906/938236) to detect if the path given is relative or absolute.