### PR TITLE
Fix typings to support module exports

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,14 +1,18 @@
 
 
-declare type ModuleExports = any;
-declare type AutoloadTree = {
-    [key: string]: AutoloadTree | ModuleExports
-};
+declare module 'auto-load' {
+    declare type ModuleExports = any;
+    declare type AutoloadTree = {
+        [key: string]: AutoloadTree | ModuleExports
+    };
 
-interface AutoloadOptions {
-    deep?: boolean,
-    js?: boolean,
-    json?: boolean
+    declare interface AutoloadOptions {
+        deep?: boolean,
+        js?: boolean,
+        json?: boolean
+    }
+
+    declare function autoload(baseDirectory: string, options?: AutoloadOptions): AutoloadTree;
+
+    export = autoload;
 }
-
-declare function autoload(baseDirectory: string, options?: AutoloadOptions): AutoloadTree;


### PR DESCRIPTION
Terribly sorry about the last pull request, I thought I had pushed all of my changes.

Those typings work if they are in the project itself, but in order to have it work correctly with module imports you have to wrap it like this.

Again, sorry for the extra work and the wasted minor version :)