### PR TITLE
fix module declaration issues

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,18 +1,16 @@
-
-
 declare module 'auto-load' {
-    declare type ModuleExports = any;
-    declare type AutoloadTree = {
+    type ModuleExports = any;
+    type AutoloadTree = {
         [key: string]: AutoloadTree | ModuleExports
     };
 
-    declare interface AutoloadOptions {
+    interface AutoloadOptions {
         deep?: boolean,
         js?: boolean,
         json?: boolean
     }
 
-    declare function autoload(baseDirectory: string, options?: AutoloadOptions): AutoloadTree;
+    function autoload(baseDirectory: string, options?: AutoloadOptions): AutoloadTree;
 
     export = autoload;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,16 +1,23 @@
-declare module 'auto-load' {
-    type ModuleExports = any;
-    type AutoloadTree = {
-        [key: string]: AutoloadTree | ModuleExports
-    };
+declare function autoload(
+  baseDirectory: string,
+  options?: autoload.AutoloadOptions
+): autoload.AutoloadTree;
 
-    interface AutoloadOptions {
-        deep?: boolean,
-        js?: boolean,
-        json?: boolean
-    }
+// Dirty hack so we can import this module using ES6 syntax
+// TypeScript won't let you import modules using ES6 syntax using `import * as` if `export =` refers to a function.
+// However, using declare namespace autoload {} TypeScript will merge the function declaration and the namespace
+// declaration so that this works. This has the added benefit of letting us expose interface types in a CommonJS
+// module.
+declare namespace autoload {
+  export interface AutoloadOptions {
+    deep?: boolean
+    js?: boolean
+    json?: boolean
+  }
 
-    function autoload(baseDirectory: string, options?: AutoloadOptions): AutoloadTree;
-
-    export = autoload;
+  export interface AutoloadTree {
+    [key: string]: AutoloadTree | any
+  }
 }
+
+export = autoload;


### PR DESCRIPTION
In TypeScript 2.8.3 (and potentially other versions since TS 1.5.x), there are two issues with the module definition:

1. There are usages of `declare` within an ambient context. This is a compiler error.
2. One cannot import the module using the ES6 splat syntax `import * as autoload from 'auto-load'`. This is a hack but it is a fairly common hack within the TS universe because using the legacy `import foo = require('foo')` syntax is really odd.

This fixes both issues.

This should also fix #13 but that's unclear as OP has not mentioned what version of TypeScript he was using and I was unable to reproduce his error as-is.